### PR TITLE
マイページのパンくずリスト部分のマークアップ

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -55,3 +55,6 @@
 @import "./modules/main-page__header__nav-box__right-box__list__item__item-box--mypage__review-listing";
 @import "./modules/main-page__header__nav-box__right-box__list__item__item-box--mypage__nav-list";
 @import "./modules/main-page__header__nav-box__right-box__list__item__item-box--mypage__nav-list__item";
+@import "./modules/main-page__bread-crumbs";
+@import "./modules/main-page__bread-crumbs__list";
+@import "./modules/main-page__bread-crumbs__list__item";

--- a/app/assets/stylesheets/modules/_main-page__bread-crumbs.scss
+++ b/app/assets/stylesheets/modules/_main-page__bread-crumbs.scss
@@ -1,0 +1,11 @@
+.main-page__bread-crumbs {
+    &__list {
+			overflow: visible;
+			width: 1020px;
+			min-width: 1068px;
+			margin: 0 auto;
+			padding: 16px 0;
+			white-space: normal;
+			font-size: 0;
+		}
+}

--- a/app/assets/stylesheets/modules/_main-page__bread-crumbs__list.scss
+++ b/app/assets/stylesheets/modules/_main-page__bread-crumbs__list.scss
@@ -1,0 +1,12 @@
+.main-page__bread-crumbs__list {
+  &__item {
+    display: inline-block;
+    font-size: 14px;
+    line-height: 1.2;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    &:last-child {
+      font-weight: 600;
+    }
+  }
+}

--- a/app/assets/stylesheets/modules/_main-page__bread-crumbs__list__item.scss
+++ b/app/assets/stylesheets/modules/_main-page__bread-crumbs__list__item.scss
@@ -1,0 +1,14 @@
+.main-page__bread-crumbs__list__item {
+  &__link {
+    color: $black;
+    &:hover {
+      text-decoration: underline;
+      color: $dark-gray;
+    }
+  }
+  &__icon-arrow-right {
+    margin: 0 8px;
+    font-size: 16px;
+    color: $dark-gray;
+  }
+}

--- a/app/views/shared/main-page/_bread-crumbs.html.haml
+++ b/app/views/shared/main-page/_bread-crumbs.html.haml
@@ -1,0 +1,11 @@
+/ 以下パンくずリストを導入した後書き直すこと
+%nav.main-page__bread-crumbs
+  %ul.main-page__bread-crumbs__list
+    %li.main-page__bread-crumbs__list__item
+      = link_to '', class: 'main-page__bread-crumbs__list__item__link' do
+        %span.main-page__bread-crumbs__list__item__text
+          メルカリ
+      = fa_icon 'angle-right', class: 'main-page__bread-crumbs__list__item__icon-arrow-right'
+    %li.main-page__bread-crumbs__list__item
+      %span.main-page__bread-crumbs__list__item__text
+        マイページ

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,2 +1,3 @@
 .main-page
   = render 'shared/main-page/main-header'
+  = render 'shared/main-page/bread-crumbs'


### PR DESCRIPTION
# What
マイページのパンくずリスト部分をマークアップした。

# Why
メルカリの基本ビューの1種類であるmain-pageのうち、マイページを先に作成し、これをほかのページで使い回すため、先に作成した。今回はパンくずリスト部分を作成した。