### PR TITLE
Create_item_model

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,0 +1,16 @@
+class Item < ApplicationRecord
+  with_options presence: true do
+    validates :name
+    validates :detail
+    validates :size
+    validates :delivery_charge
+    validates :delivery_prefecture
+    validates :delivery_time
+    validates :delivery_way
+    validates :price
+    validates :state
+    validates :large_category
+    validates :middle_category
+    validates :small_category
+  end
+end

--- a/db/migrate/20190622030511_create_items.rb
+++ b/db/migrate/20190622030511_create_items.rb
@@ -1,0 +1,20 @@
+class CreateItems < ActiveRecord::Migration[5.2]
+  def change
+    create_table :items do |t|
+      t.string :name, null: false
+      t.text :detail, null: false
+      t.integer :size, null: false
+      t.integer :delivery_charge, null: false
+      t.integer :delivery_prefecture, null: false
+      t.integer :delivery_time, null: false
+      t.integer :delivery_way, null: false
+      t.integer :price, null: false
+      t.integer :state, null: false
+      t.integer :large_category, null: false
+      t.integer :middle_category, null: false
+      t.integer :small_category, null: false
+      t.text :brand
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,25 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_09_081406) do
+ActiveRecord::Schema.define(version: 2019_06_22_030511) do
+
+  create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name", null: false
+    t.text "detail", null: false
+    t.integer "size", null: false
+    t.integer "delivery_charge", null: false
+    t.integer "delivery_prefecture", null: false
+    t.integer "delivery_time", null: false
+    t.integer "delivery_way", null: false
+    t.integer "price", null: false
+    t.integer "state", null: false
+    t.integer "large_category", null: false
+    t.integer "middle_category", null: false
+    t.integer "small_category", null: false
+    t.text "brand"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "email", default: "", null: false

--- a/test/fixtures/items.yml
+++ b/test/fixtures/items.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+
+two:
+  name: MyString

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ItemTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## WHAT
itemsのモデルを作成した。

## WHY
商品出品機能実装に必要であるため。
ただし、
外部キーで参照するカラムについては、
その関連テーブル必要なときに追加するようにする。
