### PR TITLE
ユーザー新規登録　誕生日の選択肢を自動セット

### DIFF
--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -49,4 +49,32 @@ $(document).on('turbolinks:load', function(){
       }
     })
   })
+
+  var birthYearId = '#user_birth_year';
+  var birthMonthId = '#user_birth_month';
+  var birthDayId = '#user_birth_day';
+  var getMonthDays = function(year, month) {
+    return new Date(year, month, 0).getDate();
+  };
+  var changeDaySelction = function() {
+    var year = $(birthYearId).val();
+    var month = $(birthMonthId).val();
+    if (year != 0 && month != 0) {
+      var days = getMonthDays(year, month);
+      for (var i = 1; i <= days; i++) {
+        $(birthDayId).append($("<option>").val(i).text(i));
+      }
+    } else {
+      $(birthDayId).empty();
+      $(birthDayId).append($("<option>").val("--").text("--"));
+    }
+  };
+  $(function(){
+    $(birthYearId).on('change', function(){
+      changeDaySelction();
+    })
+    $(birthMonthId).on('change', function(){
+      changeDaySelction();
+    })
+  })
 })

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -61,6 +61,7 @@ $(document).on('turbolinks:load', function(){
     var month = $(birthMonthId).val();
     if (year != 0 && month != 0) {
       var days = getMonthDays(year, month);
+      $(birthDayId).empty();
       for (var i = 1; i <= days; i++) {
         $(birthDayId).append($("<option>").val(i).text(i));
       }


### PR DESCRIPTION
# What
ユーザー新規登録で誕生日の選択肢を誕生年と誕生月から自動でありうる日のみを選択肢としてセットする

# Why
ユーザーが間違ってありえない日付をセットしないようにするため