### PR TITLE
Brand_upper_category、size_type、item_sizeのモデル作成

### DIFF
--- a/app/models/brand_upper_category.rb
+++ b/app/models/brand_upper_category.rb
@@ -1,0 +1,2 @@
+class BrandUpperCategory < ApplicationRecord
+end

--- a/app/models/item_size.rb
+++ b/app/models/item_size.rb
@@ -1,14 +1,2 @@
-class ItemSize < ActiveHash::Base
-  self.data = [
-    {id: 1, name: 'XXS以下'},
-    {id: 2, name: 'XS(SS)'},
-    {id: 3, name: 'S'},
-    {id: 4, name: 'M'},
-    {id: 5, name: 'L'},
-    {id: 6, name: 'XL(LL)'},
-    {id: 7, name: '2XL(3LL'},
-    {id: 8, name: '3XL(4LL)'},
-    {id: 9, name: '4XL(5LL)'},
-    {id: 10, name: 'FREE SIZE'}
-  ]
+class ItemSize < ApplicationRecord
 end

--- a/app/models/size_type.rb
+++ b/app/models/size_type.rb
@@ -1,0 +1,2 @@
+class SizeType < ApplicationRecord
+end

--- a/db/migrate/20190721121109_create_brand_upper_categories.rb
+++ b/db/migrate/20190721121109_create_brand_upper_categories.rb
@@ -1,0 +1,8 @@
+class CreateBrandUpperCategories < ActiveRecord::Migration[5.2]
+  def change
+    create_table :brand_upper_categories do |t|
+      t.string :name
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190721121517_create_size_types.rb
+++ b/db/migrate/20190721121517_create_size_types.rb
@@ -1,0 +1,8 @@
+class CreateSizeTypes < ActiveRecord::Migration[5.2]
+  def change
+    create_table :size_types do |t|
+      t.string :name
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190721121711_create_item_sizes.rb
+++ b/db/migrate/20190721121711_create_item_sizes.rb
@@ -1,0 +1,9 @@
+class CreateItemSizes < ActiveRecord::Migration[5.2]
+  def change
+    create_table :item_sizes do |t|
+      t.string :size
+      t.references :size_type, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190721121955_add_columns_to_small_categories.rb
+++ b/db/migrate/20190721121955_add_columns_to_small_categories.rb
@@ -1,0 +1,10 @@
+class AddColumnsToSmallCategories < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :small_categories, :brand_upper_category, foreign_key: true
+    add_reference :small_categories, :size_type, foreign_key: true
+    add_reference :middle_categories, :brand_upper_category, foreign_key: true
+    add_reference :middle_categories, :size_type, foreign_key: true
+    add_reference :brands, :brand_upper_category, foreign_key: true
+    remove_column :brands, :brand_category_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_20_105026) do
+ActiveRecord::Schema.define(version: 2019_07_21_121955) do
 
   create_table "brand_large_categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "brand_id"
@@ -39,11 +39,18 @@ ActiveRecord::Schema.define(version: 2019_07_20_105026) do
     t.index ["small_category_id"], name: "index_brand_small_categories_on_small_category_id"
   end
 
+  create_table "brand_upper_categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "brands", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "brand_category_id"
+    t.bigint "brand_upper_category_id"
+    t.index ["brand_upper_category_id"], name: "index_brands_on_brand_upper_category_id"
   end
 
   create_table "credit_cards", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -64,6 +71,14 @@ ActiveRecord::Schema.define(version: 2019_07_20_105026) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["item_id"], name: "index_images_on_item_id"
+  end
+
+  create_table "item_sizes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "size"
+    t.bigint "size_type_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["size_type_id"], name: "index_item_sizes_on_size_type_id"
   end
 
   create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -106,7 +121,11 @@ ActiveRecord::Schema.define(version: 2019_07_20_105026) do
     t.bigint "large_category_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "brand_upper_category_id"
+    t.bigint "size_type_id"
+    t.index ["brand_upper_category_id"], name: "index_middle_categories_on_brand_upper_category_id"
     t.index ["large_category_id"], name: "index_middle_categories_on_large_category_id"
+    t.index ["size_type_id"], name: "index_middle_categories_on_size_type_id"
   end
 
   create_table "receiver_informations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -126,13 +145,23 @@ ActiveRecord::Schema.define(version: 2019_07_20_105026) do
     t.index ["user_id"], name: "index_receiver_informations_on_user_id"
   end
 
+  create_table "size_types", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "small_categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
     t.integer "order_number"
     t.bigint "middle_category_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "brand_upper_category_id"
+    t.bigint "size_type_id"
+    t.index ["brand_upper_category_id"], name: "index_small_categories_on_brand_upper_category_id"
     t.index ["middle_category_id"], name: "index_small_categories_on_middle_category_id"
+    t.index ["size_type_id"], name: "index_small_categories_on_size_type_id"
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -170,15 +199,21 @@ ActiveRecord::Schema.define(version: 2019_07_20_105026) do
   add_foreign_key "brand_middle_categories", "middle_categories"
   add_foreign_key "brand_small_categories", "brands"
   add_foreign_key "brand_small_categories", "small_categories"
+  add_foreign_key "brands", "brand_upper_categories"
   add_foreign_key "credit_cards", "users"
   add_foreign_key "images", "items"
+  add_foreign_key "item_sizes", "size_types"
   add_foreign_key "items", "brands"
   add_foreign_key "items", "large_categories"
   add_foreign_key "items", "middle_categories"
   add_foreign_key "items", "small_categories"
   add_foreign_key "items", "users", column: "buyer_id"
   add_foreign_key "items", "users", column: "seller_id"
+  add_foreign_key "middle_categories", "brand_upper_categories"
   add_foreign_key "middle_categories", "large_categories"
+  add_foreign_key "middle_categories", "size_types"
   add_foreign_key "receiver_informations", "users"
+  add_foreign_key "small_categories", "brand_upper_categories"
   add_foreign_key "small_categories", "middle_categories"
+  add_foreign_key "small_categories", "size_types"
 end


### PR DESCRIPTION
# What
Brand_upper_category、size_type、item_sizeのモデルを作成し、これと関連のあるモデルに外部キーカラムを追加した

# Why
active_hashだとブランド一覧ページおよび検索ページ作成の際、コードが複雑になるため、両方からアソシエーションが組めるテーブルに変更する。