### PR TITLE
Edit item controller, buy_complete.haml

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -156,7 +156,7 @@ class ItemsController < ApplicationController
 
   private
   def items_params
-    params.require(:item).permit(:name, :detail,:item_condition_id,:delivery_charge_id,:prefecture_id,:delivery_time_id,:delivery_way_id,:price,:item_size_id,:large_category_id,:middle_category_id,:small_category_id, images_attributes: [:image]).merge(seller_id: current_user.id, item_state_id: 1)
+    params.require(:item).permit(:name, :detail,:item_condition_id,:delivery_charge_id,:prefecture_id,:delivery_time_id,:delivery_way_id,:price,:item_size_id,:large_category_id,:middle_category_id,:small_category_id, images_attributes: [:id,:image]).merge(seller_id: current_user.id, item_state_id: 1)
   end
 
   def brand_params

--- a/app/views/items/buy_complete.html.haml
+++ b/app/views/items/buy_complete.html.haml
@@ -37,10 +37,12 @@
       = image_tag credit_card_logo(current_user.credit_card.card_number), class: 'main-page__body__content__chapter__inner__payment-list__item__form__figure__image'
     %section.single-page__body__flow
       %h3 発送通知後の流れ
-      %div
-        %i.icon-good
-        %i.icon-normal
-        %i.icon-bad
+      %div 
+        = fa_icon 'sun-o', class: ['main-page__item-container__content-box__detail__container__content__body__inner__content__icon', 'main-page__item-container__content-box__detail__container__content__body__inner__content__icon--normal']
+        = fa_icon 'laugh', class: ['main-page__item-container__content-box__detail__container__content__body__inner__content__icon', 'main-page__item-container__content-box__detail__container__content__body__inner__content__icon--good']
+        = fa_icon 'meh', class: ['main-page__item-container__content-box__detail__container__content__body__inner__content__icon', 'main-page__item-container__content-box__detail__container__content__body__inner__content__icon--normal']
+        = fa_icon 'frown', class: ['main-page__item-container__content-box__detail__container__content__body__inner__content__icon', 'main-page__item-container__content-box__detail__container__content__body__inner__content__icon--bad']
+        = fa_icon 'sun-o', class: ['main-page__item-container__content-box__detail__container__content__body__inner__content__icon', 'main-page__item-container__content-box__detail__container__content__body__inner__content__icon--normal']
       %p
         商品を受け取ったら
         %br>/


### PR DESCRIPTION
## What 
商品機能に関連する細かな修正を行った

## WHY

- Edit_item_controller
   ⇨　商品情報更新時、image更新ができないための対応。

- Edit_buy_complete_icon
   ⇨　商品購入完了画面のアイコンの追加のため。

[![Image from Gyazo](https://i.gyazo.com/aa3b0e856a047215a9ff045c3275c543.png)](https://gyazo.com/aa3b0e856a047215a9ff045c3275c543)
