### PR TITLE
メインページヘッダーのマイページ見切れの解消

### DIFF
--- a/app/assets/stylesheets/modules/_main-page__header__nav-box__right-box.scss
+++ b/app/assets/stylesheets/modules/_main-page__header__nav-box__right-box.scss
@@ -12,18 +12,6 @@
       &:last-child {
         padding-right: 0;
       }
-      &--mypage {
-        right: 0;
-        position: absolute;
-        top: 44px;
-        z-index: 1;
-        display: none;
-        width: 320px;
-        background: $white;
-        -webkit-box-shadow: 0 1px 1px 0 rgba(0,0,0,0.24);
-        box-shadow: 0 1px 1px 0 rgba(0,0,0,0.24);
-        font-size: 14px;
-      }
       &--login {
         position: static;
         padding: 0;
@@ -124,10 +112,9 @@
         box-shadow: 0 1px 1px 0 rgba(0,0,0,0.24);
         font-size: 14px;
         left: 0;
-        &--active {
-          display: block;
-        }
         &--mypage {
+          left: auto;
+          right: 0;
           &__user-state {
             text-align: center;
           }
@@ -240,6 +227,9 @@
               }
             }
           }
+        }
+        &--active {
+          display: block;
         }
         &__item {
           position: relative;


### PR DESCRIPTION
# What
メインページヘッダーのマイページ部のドロー部分が表示された時、右側が見切れていたのを解消した

# Why
メインページヘッダーのマイページ部のドロー部分をすべて表示させるため

# 見た目
https://gyazo.com/9a16637e6ac81b75e888a9ed23c21f6e